### PR TITLE
Unquote c on set-cell!=, use clojure.core/destructure

### DIFF
--- a/src/javelin/core.clj
+++ b/src/javelin/core.clj
@@ -26,7 +26,7 @@
   `(let [~binding ~resource] ~@body ~binding))
 
 (defn extract-syms [bindings]
-  (map first (partition 2 (cljs.core/destructure bindings))))
+  (map first (partition 2 (clojure.core/destructure bindings))))
 
 (defn extract-syms-without-autogen [bindings]
   (let [syms1 (set (extract-syms bindings))
@@ -201,7 +201,7 @@
   (defmacro set-cell!=
     ([c expr] (set-cell* c expr &env))
     ([c expr f]
-       `(with-let [c# c]
+       `(with-let [c# ~c]
           (set-cell!= ~c ~expr)
           (set! (.-update c#) ~f))))
 


### PR DESCRIPTION
Fixes #32 

The unrelated change of destructure is because cljs.core/destructure is pretty recent and don't work on older versions of clojurescript.