### PR TITLE
Fix bug where formulet rejects an odd number of binding pairs

### DIFF
--- a/src/javelin/core.clj
+++ b/src/javelin/core.clj
@@ -309,9 +309,9 @@
       (deref c) ;=> 347
   "
   [bindings & body]
+  (assert (and (vector? bindings) (even? (count bindings)))
+          "first argument must be a vector of binding pairs")
   (let [binding-pairs (partition 2 bindings)]
-    (assert (and (vector? bindings) (even? (count binding-pairs)))
-            "first argument must be a vector of binding pairs")
     `((formula (fn [~@(map first binding-pairs)] ~@body))
       ~@(map second binding-pairs))))
 

--- a/test/javelin/core_test.cljs
+++ b/test/javelin/core_test.cljs
@@ -809,7 +809,8 @@
           z (cell {:e 5 :f 6})
           u (atom 0)
           v (formulet [{:keys [a b]} x
-                       {:keys [c d]} y]
+                       {:keys [c d]} y
+                       _ {}]
               (swap! u inc)
               (+ a b c d (:e @z) (:f @z)))]
       (testing "initial value is computed correctly"


### PR DESCRIPTION
I found a bug where `formulet` throws an assertion error, "first argument must be a vector of binding pairs," when provided with an odd number of binding _pairs_. Looks like a simple typo where we should be counting `bindings` instead of `binding-pairs`. I've lifted the `assert` outside of the `let` to make this extra clear.

I've adjusted the test cases to demonstrate the bug in the absence of this fix. 