### PR TITLE
formulet assertion should count bindings, not binding-pairs

### DIFF
--- a/src/javelin/core.clj
+++ b/src/javelin/core.clj
@@ -310,7 +310,7 @@
   "
   [bindings & body]
   (let [binding-pairs (partition 2 bindings)]
-    (assert (and (vector? bindings) (even? (count binding-pairs)))
+    (assert (and (vector? bindings) (even? (count bindings)))
             "first argument must be a vector of binding pairs")
     `((formula (fn [~@(map first binding-pairs)] ~@body))
       ~@(map second binding-pairs))))


### PR DESCRIPTION
This fixes a small bug where you couldn't use `formulet` with a non-even number of bindings.

```
(macroexpand '(formulet [a (cell 123)]
                           (+ 1 2)))
Unexpected error (AssertionError) macroexpanding formulet at (REPL:1:1).
Assert failed: first argument must be a vector of binding pairs
```